### PR TITLE
Fix FloatVectorOperationsBase

### DIFF
--- a/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.h
+++ b/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.h
@@ -63,7 +63,7 @@ class ScopedNoDenormals;
     @tags{Audio}
 */
 template <typename FloatType, typename CountType>
-struct FloatVectorOperationsBase
+struct JUCE_API FloatVectorOperationsBase
 {
     /** Clears a vector of floating point numbers. */
     static void JUCE_CALLTYPE clear (FloatType* dest, CountType numValues) noexcept;


### PR DESCRIPTION
Apply `JUCE_API` macro to class `FloatVectorOperationsBase` so that it can be exported and linked as a dynamic library.